### PR TITLE
Config file for custom middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The Media Manager service provider **does not** automatically register routes fo
 \TalvBansal\MediaManager\Routes\MediaRoutes::get();
 ```
 
+The routes have no middleware assigned. So if you want to wrap the Media Manager routes in a special middleware (e.g. 'web' or 'auth'), you can publish the config file via:
+```
+php artisan vendor:publish --tag=media-manager-config
+```
+Now you can find the `media-manager.php` in your config-directory and customize your middlewares. Simple add them to the middleware-array.
+
 After registering the Media Manager service provider, you should publish the Media Manager assets using the `vendor:publish` Artisan command: 
 ```bash
 php artisan vendor:publish --tag=media-manager --force

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Fabian
+ * Date: 29.05.17
+ * Time: 16:50
+ */
+
+return [
+
+	'routes' => [
+		'middleware' => ['web']
+	]
+];

--- a/src/Providers/MediaManagerServiceProvider.php
+++ b/src/Providers/MediaManagerServiceProvider.php
@@ -20,6 +20,11 @@ class MediaManagerServiceProvider extends ServiceProvider
         // Load language files
         $this->loadTranslationsFrom(MEDIA_MANAGER_BASE_PATH.'/resources/lang', 'media-manager');
 
+        // Publishes config file
+	    $this->publishes([
+	    	__DIR__ . '/../Config/config.php' => config_path('media-manager.php')
+	    ], 'media-manager-config');
+
         if ($this->app->runningInConsole()) {
             $this->defineResources();
         }

--- a/src/Routes/MediaRoutes.php
+++ b/src/Routes/MediaRoutes.php
@@ -7,21 +7,40 @@ use Route;
 class MediaRoutes
 {
     /**
-     * Get all of the media manager routes.
+     * Checks, if a config-file is and if custom middleware is set in the config file.
+     * Gives all the media manager routes back.
      */
     public static function get()
     {
+    	if('media-manager.routes.middleware' === NULL){
 
-        // Media Manager Routes
-        Route::get('/admin/browser/index', '\TalvBansal\MediaManager\Http\Controllers\MediaController@ls');
+    		// If no config is set, routes will be loaded normally without middleware..
+    		self::loadRoutes();
+	    } else {
 
-        Route::post('admin/browser/file', '\TalvBansal\MediaManager\Http\Controllers\MediaController@uploadFiles');
-        Route::delete('/admin/browser/delete', '\TalvBansal\MediaManager\Http\Controllers\MediaController@deleteFile');
-        Route::post('/admin/browser/folder', '\TalvBansal\MediaManager\Http\Controllers\MediaController@createFolder');
-        Route::delete('/admin/browser/folder', '\TalvBansal\MediaManager\Http\Controllers\MediaController@deleteFolder');
+    		// .. otherwise the routes will be wrapped in a middleware
+		    Route::group(['middleware' => config('media-manager.routes.middleware')], function(){
+			    self::loadRoutes();
+		    });
+	    }
 
-        Route::post('/admin/browser/rename', '\TalvBansal\MediaManager\Http\Controllers\MediaController@rename');
-        Route::get('/admin/browser/directories', '\TalvBansal\MediaManager\Http\Controllers\MediaController@allDirectories');
-        Route::post('/admin/browser/move', '\TalvBansal\MediaManager\Http\Controllers\MediaController@move');
+    }
+
+	/**
+	 * Get all of the media manager routes.
+	 */
+    private static function loadRoutes()
+    {
+	    // Media Manager Routes
+	    Route::get('/admin/browser/index', '\TalvBansal\MediaManager\Http\Controllers\MediaController@ls');
+
+	    Route::post('admin/browser/file', '\TalvBansal\MediaManager\Http\Controllers\MediaController@uploadFiles');
+	    Route::delete('/admin/browser/delete', '\TalvBansal\MediaManager\Http\Controllers\MediaController@deleteFile');
+	    Route::post('/admin/browser/folder', '\TalvBansal\MediaManager\Http\Controllers\MediaController@createFolder');
+	    Route::delete('/admin/browser/folder', '\TalvBansal\MediaManager\Http\Controllers\MediaController@deleteFolder');
+
+	    Route::post('/admin/browser/rename', '\TalvBansal\MediaManager\Http\Controllers\MediaController@rename');
+	    Route::get('/admin/browser/directories', '\TalvBansal\MediaManager\Http\Controllers\MediaController@allDirectories');
+	    Route::post('/admin/browser/move', '\TalvBansal\MediaManager\Http\Controllers\MediaController@move');
     }
 }


### PR DESCRIPTION
With this modification a user of this package is able to wrap all routes with the needed middleware.

NOTE: This option is optional. That means, if one is not publishing the config, all will behave normal (so updates won't crash).

Created/modified the following files:
- config.php (will be renamed to media-manager.php after publishing):
- readme.md: A note on how to use the config file
- MediaManagerServiceProvider.php: publishing the config file
- MediaRoutes.php: A second method to get all routes. Modified the
get()-Method to check, if a config-value is set.