### PR TITLE
Added support for specifying access mode while uploading 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Read more about the public disk [on the Laravel documentation](https://laravel.c
 If you wish to change the disk that media manager stores its files to you can create a new entry in your projects `.env` file with the name of `MEDIA_MANAGER_STORAGE_DISK` and the name of the disk configured within `config/filesystems.php`.
 Any [flysystem](https://flysystem.thephpleague.com/) adapter which supports the `url` method should work.
 
+## Note:
+Some cloud flysystems like `AWS S3` supports access modes. All File Uploads via media manger are `public` by default.It can be changed by specifying it in env `MEDIA_MANAGER_ACCESS` or directly via config `media-manager.php` if you have published the config in your project.
+
 ## # Getting Started
 
 The Media Manager is written in `vue.js 2.0` and comes bundled with all the dependencies required to get going very quickly.

--- a/src/Config/media-manager.php
+++ b/src/Config/media-manager.php
@@ -13,6 +13,6 @@ return [
         'prefix'     => env('MEDIA_MANAGER_ROUTE_PREFIX', '/admin/'),
     ],
 
-    'disk' => env('MEDIA_MANAGER_STORAGE_DISK', 'public'),
+    'disk'   => env('MEDIA_MANAGER_STORAGE_DISK', 'public'),
     'access' => env('MEDIA_MANAGER_ACCESS', 'public'),
 ];

--- a/src/Config/media-manager.php
+++ b/src/Config/media-manager.php
@@ -14,4 +14,5 @@ return [
     ],
 
     'disk' => env('MEDIA_MANAGER_STORAGE_DISK', 'public'),
+    'access' => env('MEDIA_MANAGER_ACCESS', 'public'),
 ];

--- a/src/Services/MediaManager.php
+++ b/src/Services/MediaManager.php
@@ -21,7 +21,7 @@ class MediaManager implements FileUploaderInterface, FileMoverInterface
      * @var FilesystemAdapter
      */
     protected $disk;
-    
+
     /**
      * @var Access Mode of the file as S3 uploads are private by default
      */

--- a/src/Services/MediaManager.php
+++ b/src/Services/MediaManager.php
@@ -21,6 +21,11 @@ class MediaManager implements FileUploaderInterface, FileMoverInterface
      * @var FilesystemAdapter
      */
     protected $disk;
+    
+    /**
+     * @var Access Mode of the file as S3 uploads are private by default
+     */
+    protected $access;
 
     /**
      * @var PhpRepository
@@ -47,6 +52,7 @@ class MediaManager implements FileUploaderInterface, FileMoverInterface
     public function __construct(PhpRepository $mimeDetect)
     {
         $this->diskName = config('media-manager.disk');
+        $this->access = config('media-manager.access');
         $this->disk = Storage::disk($this->diskName);
         $this->mimeDetect = $mimeDetect;
     }
@@ -416,7 +422,7 @@ class MediaManager implements FileUploaderInterface, FileMoverInterface
                 return $uploaded;
             }
 
-            if (!$file->storeAs($path, $fileName, $this->diskName)) {
+            if (!$file->storeAs($path, $fileName, $this->diskName, $this->access)) {
                 $this->errors[] = trans('media-manager::messages.upload_error', ['entity' => $fileName]);
 
                 return $uploaded;


### PR DESCRIPTION
File uploaded through Storage Flysystems cloud drivers are private by default
This PR added support to modify the access modes and the file access mode is defaulted to public in config