### PR TITLE
Mimes of uppercase files extension are resolved.

### DIFF
--- a/src/Services/MediaManager.php
+++ b/src/Services/MediaManager.php
@@ -193,7 +193,7 @@ class MediaManager implements FileUploaderInterface, FileMoverInterface
      */
     public function fileMimeType($path)
     {
-        $type = $this->mimeDetect->findType(pathinfo($path, PATHINFO_EXTENSION));
+        $type = $this->mimeDetect->findType(strtolower(pathinfo($path, PATHINFO_EXTENSION)));
         if (!empty($type)) {
             return $type;
         }


### PR DESCRIPTION
Some camera output files with extension in uppercase.
It is common to have one picture called "IMG_3063.JPG" for example.
In that case, the picture isn't displayed by the media-manager.

This little correction allow uppercase extensions.