### PR TITLE
Pass $path by reference, so the path of each folder in the breadcrumb…

### DIFF
--- a/src/Services/MediaManager.php
+++ b/src/Services/MediaManager.php
@@ -143,7 +143,7 @@ class MediaManager implements FileUploaderInterface, FileMoverInterface
         $folders = collect(explode('/', $folder));
         $path = '';
 
-        return $folders->reduce(function ($crumbs, $folder) use ($path) {
+        return $folders->reduce(function ($crumbs, $folder) use (&$path) {
             $path .= '/'.$folder;
             $crumbs[$path] = $folder;
 


### PR DESCRIPTION
… is correct.

To test it, log $crumbs inside the reduce call before the patch (or create multiple sub folders from the media-manager and go one folder up.