### PR TITLE
Fix PHP 5.6 memory issues with travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2
 
 env:
   - NODE_RELEASE=8.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   - NODE_RELEASE=8.x
 
 before_install:
+  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - sudo rm -rf ~/.nvm - curl -sL "https://deb.nodesource.com/setup_${NODE_RELEASE}" | sudo -E bash -
   - sudo apt-get install -y nodejs
   - travis_retry composer self-update


### PR DESCRIPTION
Composer was failing since it was running out of memory with travis ci.

Composer automatically raises the memory limit to 1.5Gb but looks like thats not enough for php 5.6.
This patch raises it to 2Gb which isn't ideal but since it gets the job done and its for php 5.6 I think its an acceptable fix.